### PR TITLE
Old pdfs is not entirely precise

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 - Edit the settings in the administration page.
 - Extract the current files from your cloud using the **./occ nextant:index** command 
 - Have a look to this [explanation on how Nextant works](https://github.com/daita/nextant/wiki/Extracting,-Live-Update)
-- _(Optional)_ [Installing Tesseract](https://github.com/tesseract-ocr/tesseract/wiki) ([Optical Character Recognition](https://en.wikipedia.org/wiki/Optical_character_recognition) (OCR) Engine) will allow Nextant to extract text from image file and old pdf.
+- _(Optional)_ [Installing Tesseract](https://github.com/tesseract-ocr/tesseract/wiki) ([Optical Character Recognition](https://en.wikipedia.org/wiki/Optical_character_recognition) (OCR) Engine) will allow Nextant to extract text from image file and pdfs without a text layer.
 
 
 ## Building the app


### PR DESCRIPTION
While I said that I have this issue with old pdfs, the problem is that
whenever an image is converted to a pdf, there is no text if no OCR is
run on it. So it can happen with any pdf.

"text layer" is still not entirely correct, as "layers" are not really a thing in pdfs but I think this is still clearer.