### PR TITLE
adds scheme to Solarium endpoint

### DIFF
--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -287,6 +287,7 @@ class ConfigService
             'endpoint' => array(
                 'localhost' => array(
                     'timeout' => ($config['timeout'] < 5) ? 5 : $config['timeout'],
+                    'scheme' => $t['scheme'],
                     'host' => $t['host'],
                     'port' => $t['port'],
                     'core' => $config['solr_core'],


### PR DESCRIPTION
Currently it is not possible to connect to Solr server that is available via HTTPS only. You can pass a scheme to the endpoint to address this, see https://github.com/solariumphp/solarium/issues/267

This commit updates the toSolarium() function to pass the scheme to the endpoint as well. 

Fixes #129