### PR TITLE
Readme.md - update instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@
 - Have a look to this [explanation on how Nextant works](https://github.com/nextcloud/nextant/wiki/Extracting,-Live-Update)
 - _(Optional)_ [Installing Tesseract](https://github.com/tesseract-ocr/tesseract/wiki) ([Optical Character Recognition](https://en.wikipedia.org/wiki/Optical_character_recognition) (OCR) Engine) will allow Nextant to extract text from image file and pdfs without a text layer.
 
--## Scripted installation (Ubuntu)
- -The developers of the [Nextcloud VM](https://github.com/nextcloud/vm) has made a [script](https://github.com/nextcloud/vm/blob/master/apps/nextant.sh) that you can use.
- -Please note that you must change the variables in the script to suit your config before you run it.
- -
- -To get the script, please type the folloing command: `wget https://github.com/nextcloud/vm/blob/master/apps/nextant.sh` and then run the script with `sudo bash nextant.sh`.
- -
- -Please report any issues regarding the script in the [Nextcloud VM repo](https://github.com/nextcloud/vm/issues).
- -
+## Scripted installation (Ubuntu)
+The developers of the [Nextcloud VM](https://github.com/nextcloud/vm) has made a [script](https://raw.githubusercontent.com/nextcloud/vm/master/static/nextant.sh) that you can use.
+Please note that you must change the variables in the script to suit your config before you run it.
+
+To get the script, please type the folloing command: `wget https://github.com/nextcloud/vm/blob/master/static/nextant.sh` and then run the script with `sudo bash nextant.sh`.
+
+Please report any issues regarding the script in the [Nextcloud VM repo](https://github.com/nextcloud/vm/issues).
+
 ## Building the app
 
 The app can be built by using the provided Makefile by running:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 ## Installation
 
 - [You first need to install a Solr servlet](https://github.com/nextcloud/nextant/wiki)
-- Download the .zip from the appstore, unzip and place this app in **nextcloud/apps/** (or clone the github and build the app yourself)
+- Download the .tar.gz from the [https://apps.nextcloud.com/apps/nextant](appstore), unzip and place this app in **nextcloud/apps/** (or clone the github and build the app yourself)
 - Enable the app in the app list,
 - Edit the settings in the administration page.
 - Enable Nextant using the **./occ app:enable nextant** command
@@ -40,6 +40,14 @@
 - Have a look to this [explanation on how Nextant works](https://github.com/nextcloud/nextant/wiki/Extracting,-Live-Update)
 - _(Optional)_ [Installing Tesseract](https://github.com/tesseract-ocr/tesseract/wiki) ([Optical Character Recognition](https://en.wikipedia.org/wiki/Optical_character_recognition) (OCR) Engine) will allow Nextant to extract text from image file and pdfs without a text layer.
 
+-## Scripted installation (Ubuntu)
+ -The developers of the [Nextcloud VM](https://github.com/nextcloud/vm) has made a [script](https://github.com/nextcloud/vm/blob/master/apps/nextant.sh) that you can use.
+ -Please note that you must change the variables in the script to suit your config before you run it.
+ -
+ -To get the script, please type the folloing command: `wget https://github.com/nextcloud/vm/blob/master/apps/nextant.sh` and then run the script with `sudo bash nextant.sh`.
+ -
+ -Please report any issues regarding the script in the [Nextcloud VM repo](https://github.com/nextcloud/vm/issues).
+ -
 ## Building the app
 
 The app can be built by using the provided Makefile by running:


### PR DESCRIPTION
Added missing instructions in the installation process (enable Nextant, test Solr config), and removed instructions and link to the now non existent install script.

I looked around and the only place that I found those instructions after battling with the "nextant not configured" error for a few days was a cache of the now deleted install script.